### PR TITLE
Setting storage buffers for shader

### DIFF
--- a/include/Shaders.hpp
+++ b/include/Shaders.hpp
@@ -42,7 +42,7 @@ class Shader
     Shader() = delete;
     Shader(
         const std::filesystem::path& fragmentBasePath, uint32_t uniformBufferCount = 0,
-        uint32_t samplerCount = 1
+        uint32_t samplerCount = 1, const std::vector<uint32_t>& storageBufferSizes = {}
     );
     ~Shader();
 
@@ -56,6 +56,7 @@ class Shader
     void unbind() const;
 
     void setTextureSampler(const uint32_t binding, const Texture& texture, const Sampler& sampler);
+    void setStorageBufferData(const uint32_t index, const void* data, const uint32_t len);
 
     template <typename UniformType>
     void setUniform(const uint32_t binding, const UniformType& data) const
@@ -72,6 +73,11 @@ class Shader
 
     uint32_t m_samplerCount = 0;
     std::vector<SDL_GPUTextureSamplerBinding> m_samplerBindings;
+
+    uint32_t m_storageBufferCount = 0;
+    std::vector<SDL_GPUBuffer*> m_storageBuffers;
+    std::vector<uint32_t> m_storageBufferSizes;
+    std::vector<SDL_GPUTransferBuffer*> m_storageTransferBuffers;
 
     friend void _quit();
 

--- a/src/shaders.cpp
+++ b/src/shaders.cpp
@@ -2,6 +2,7 @@
 #include <nanobind/ndarray.h>
 #include <nanobind/stl/filesystem.h>
 #include <nanobind/stl/string.h>
+#include <nanobind/stl/vector.h>
 #endif  // KRAKEN_ENABLE_PYTHON
 
 #include <algorithm>

--- a/src/shaders.cpp
+++ b/src/shaders.cpp
@@ -47,7 +47,7 @@ static std::vector<Shader*> _shaderStates;
 
 Shader::Shader(
     const std::filesystem::path& fragmentBasePath, const uint32_t uniformBufferCount,
-    const uint32_t samplerCount
+    const uint32_t samplerCount, const std::vector<uint32_t>& storageBufferSizes
 )
 {
     SDL_GPUShaderFormat formats = SDL_GetGPUShaderFormats(renderer::_getGPUDevice());
@@ -98,7 +98,7 @@ Shader::Shader(
         .stage = SDL_GPU_SHADERSTAGE_FRAGMENT,
         .num_samplers = samplerCount,
         .num_storage_textures = 0,  // Not usable yet
-        .num_storage_buffers = 0,   // Not usable yet
+        .num_storage_buffers = storageBufferCount,
         .num_uniform_buffers = uniformBufferCount,
         .props = 0,
     };
@@ -114,14 +114,51 @@ Shader::Shader(
     }
     SDL_free(code);
 
+    m_storageBufferCount = static_cast<uint32_t>(storageBufferSizes.size());
+    m_storageBufferSizes = storageBufferSizes;
+
+    if (m_storageBufferCount > 0)
+    {
+        for (uint32_t i = 0; i < storageBufferCount; i++)
+        {
+            SDL_GPUBufferCreateInfo bufferInfo{
+                .usage = SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ,
+                .size = storageBufferSizes[i],
+                .props = 0
+            };
+            SDL_GPUBuffer* buffer = SDL_CreateGPUBuffer(renderer::_getGPUDevice(), &bufferInfo);
+            if (!buffer) 
+            {
+                throw std::runtime_error("Failed to create a GPU buffer: " + std::string(SDL_GetError()));
+            }
+            m_storageBuffers.push_back(buffer);
+            
+            SDL_GPUTransferBufferCreateInfo transferBufferInfo{
+                .usage = SDL_GPU_TRANSFERBUFFERUSAGE_UPLOAD,
+                .size  = storageBufferSizes[i],
+                .props = 0
+            };
+            SDL_GPUTransferBuffer* transferBuffer = SDL_CreateGPUTransferBuffer(
+                renderer::_getGPUDevice(),
+                &transferBufferInfo
+            );
+            if (!transferBuffer)
+            {
+                throw std::runtime_error("Failed to create a GPU storage transfer buffer: "
+                    + std::string(SDL_GetError()));
+            }
+            m_storageTransferBuffers.push_back(transferBuffer);
+        }
+    }
+
     SDL_GPURenderStateCreateInfo renderStateInfo{
         .fragment_shader = m_fragShader,
         .num_sampler_bindings = 0,
         .sampler_bindings = nullptr,
         .num_storage_textures = 0,    // Not usable yet
         .storage_textures = nullptr,  // Not usable yet
-        .num_storage_buffers = 0,     // Not usable yet
-        .storage_buffers = nullptr,   // Not usable yet
+        .num_storage_buffers = storageBufferCount,
+        .storage_buffers = m_storageBuffers.data(),
         .props = 0,
     };
     m_renderState = SDL_CreateGPURenderState(renderer::_get(), &renderStateInfo);
@@ -153,11 +190,17 @@ Shader& Shader::operator=(Shader&& other) noexcept
     if (this != &other)
     {
         // Clean up existing GPU resources first
+        for (SDL_GPUTransferBuffer* transferBuffer : m_storageTransferBuffers)
+            SDL_ReleaseGPUTransferBuffer(renderer::_getGPUDevice(), transferBuffer);
+        for (SDL_GPUBuffer* buffer : m_storageBuffers)
+            SDL_ReleaseGPUBuffer(renderer::_getGPUDevice(), buffer);
         if (m_renderState)
             SDL_DestroyGPURenderState(m_renderState);
         if (m_fragShader)
             SDL_ReleaseGPUShader(renderer::_getGPUDevice(), m_fragShader);
-
+        m_storageTransferBuffers.clear();
+        m_storageBuffers.clear();
+            
         // Remove "other" from the registry to prevent dangling pointers.
         auto it = std::find(_shaderStates.begin(), _shaderStates.end(), &other);
         if (it != _shaderStates.end())
@@ -193,6 +236,12 @@ Shader::~Shader()
 
     if (m_fragShader)
     {
+        for (SDL_GPUTransferBuffer* transferBuffer : m_storageTransferBuffers)
+            SDL_ReleaseGPUTransferBuffer(renderer::_getGPUDevice(), transferBuffer);
+        for (SDL_GPUBuffer* buffer : m_storageBuffers)
+            SDL_ReleaseGPUBuffer(renderer::_getGPUDevice(), buffer);
+        m_storageTransferBuffers.clear();
+        m_storageBuffers.clear();
         SDL_ReleaseGPUShader(renderer::_getGPUDevice(), m_fragShader);
         m_fragShader = nullptr;
     }
@@ -232,6 +281,41 @@ void Shader::setTextureSampler(
         .texture = texture.getGPU(),
         .sampler = sampler.getSDL(),
     };
+}
+
+void Shader::setStorageBufferData(const uint32_t index, const void* data, const uint32_t len)
+{
+    if (!data)
+        throw std::runtime_error("Storage buffer data pointer is null");
+    if (index >= m_storageBufferCount)
+        throw std::runtime_error("Storage buffer index out of range");
+    if (len > m_storageBufferSizes[index])
+        throw std::runtime_error("Data size exceeds capacity");
+
+    uint8_t* ptr = static_cast<uint8_t*>(SDL_MapGPUTransferBuffer(
+        renderer::_getGPUDevice(),
+        m_storageTransferBuffers[index],
+        true
+    ));
+    memcpy(ptr, data, len);
+    SDL_UnmapGPUTransferBuffer(renderer::_getGPUDevice(), m_storageTransferBuffers[index]);
+
+    SDL_GPUCommandBuffer* command_buffer = SDL_AcquireGPUCommandBuffer(
+        renderer::_getGPUDevice()
+    );
+    SDL_GPUCopyPass* copy = SDL_BeginGPUCopyPass(command_buffer);
+    SDL_GPUTransferBufferLocation location{
+        .transfer_buffer = m_storageTransferBuffers[index],
+        .offset = 0
+    };
+    SDL_GPUBufferRegion region{
+        .buffer = m_storageBuffers[index],
+        .offset = 0,
+        .size = len
+    };
+    SDL_UploadToGPUBuffer(copy, &location, &region, true);
+    SDL_EndGPUCopyPass(copy);
+    SDL_SubmitGPUCommandBuffer(command_buffer);
 }
 
 Sampler::Sampler(
@@ -409,6 +493,45 @@ Args:
 Raises:
     TypeError: If the object does not provide compatible uniform data.
     RuntimeError: If the uniform data cannot be set.
+            )doc"
+        )
+        .def(
+            "set_storage_buffer_data",
+            [](const Shader& self, const Uint32 index, nb::object data)
+            {
+                Py_buffer view;
+
+                if (PyObject_GetBuffer(data.ptr(), &view, PyBUF_CONTIG_RO) != 0)
+                    throw nb::type_error("Expected a buffer-compatible object for uniform data");
+
+                try
+                {
+                    if (view.buf == nullptr || view.len < 0)
+                        throw nb::type_error("Invalid buffer object");
+
+                    self.setStorageBufferData(index, data.buf, static_cast<uint32_t>(data.len));
+                }
+                catch (...)
+                {
+                    PyBuffer_Release(&view);
+                    throw;
+                }
+
+                PyBuffer_Release(&view);
+            },
+            "index"_a, "data"_a,
+            nb::sig("def set_storage_buffer_data(self, index: int, data: collections.abc.Buffer, /) -> None"),
+            R"doc(
+Sets the data for a data storage buffer (an HLSL StructuredBuffer, untested for GLSL) for the fragment shader
+at the specified index.
+
+Args:
+    index (int): Shader buffer binding index.
+    data (Buffer): Buffer-compatible object containing the bytes to be given to the shader buffer.
+
+Raises:
+    TypeError: If the object does not provide compatible storage buffer data.
+    RuntimeError: If the storage buffer data cannot be set.
             )doc"
         )
         .def(

--- a/src/shaders.cpp
+++ b/src/shaders.cpp
@@ -432,14 +432,15 @@ Args:
 Encapsulates a GPU shader and its associated render state.
         )doc")
         .def(
-            nb::init<const std::filesystem::path&, uint32_t, uint32_t>(), "fragment_base_path"_a,
-            "uniform_buffer_count"_a = 0, "sampler_count"_a = 1, R"doc(
+            nb::init<const std::filesystem::path&, uint32_t, uint32_t, const std::vector<uint32_t>&>(), "fragment_base_path"_a,
+            "uniform_buffer_count"_a = 0, "sampler_count"_a = 1, "storage_buffer_sizes"_a = {}, R"doc(
 Create a Shader instance from a fragment shader file.
 
 Args:
     fragment_base_path (str): Base file name of the fragment shader. The appropriate backend extension will be appended automatically.
     uniform_buffer_count (int, optional): Number of uniform buffers used by the shader. Default is 0.
     sampler_count (int, optional): Number of samplers used by the shader. Default is 1.
+    storage_buffer_sizes (Sequence[int], optional): The storage buffer sizes in bytes used by the shader. Default is an empty sequence.
 
 Raises:
     RuntimeError: If the shader cannot be loaded or created.

--- a/src/shaders.cpp
+++ b/src/shaders.cpp
@@ -59,6 +59,7 @@ Shader::Shader(
     SDL_GPUShaderFormat shaderFormat = SDL_GPU_SHADERFORMAT_INVALID;
     const char* entrypoint;
     std::string extension;
+    m_storageBufferCount = static_cast<uint32_t>(storageBufferSizes.size());
 
     if (formats & SDL_GPU_SHADERFORMAT_SPIRV)
     {
@@ -98,7 +99,7 @@ Shader::Shader(
         .stage = SDL_GPU_SHADERSTAGE_FRAGMENT,
         .num_samplers = samplerCount,
         .num_storage_textures = 0,  // Not usable yet
-        .num_storage_buffers = storageBufferCount,
+        .num_storage_buffers = m_storageBufferCount,
         .num_uniform_buffers = uniformBufferCount,
         .props = 0,
     };
@@ -114,12 +115,11 @@ Shader::Shader(
     }
     SDL_free(code);
 
-    m_storageBufferCount = static_cast<uint32_t>(storageBufferSizes.size());
     m_storageBufferSizes = storageBufferSizes;
 
     if (m_storageBufferCount > 0)
     {
-        for (uint32_t i = 0; i < storageBufferCount; i++)
+        for (uint32_t i = 0; i < m_storageBufferCount; i++)
         {
             SDL_GPUBufferCreateInfo bufferInfo{
                 .usage = SDL_GPU_BUFFERUSAGE_GRAPHICS_STORAGE_READ,
@@ -157,7 +157,7 @@ Shader::Shader(
         .sampler_bindings = nullptr,
         .num_storage_textures = 0,    // Not usable yet
         .storage_textures = nullptr,  // Not usable yet
-        .num_storage_buffers = storageBufferCount,
+        .num_storage_buffers = m_storageBufferCount,
         .storage_buffers = m_storageBuffers.data(),
         .props = 0,
     };
@@ -509,7 +509,7 @@ Raises:
                     if (view.buf == nullptr || view.len < 0)
                         throw nb::type_error("Invalid buffer object");
 
-                    self.setStorageBufferData(index, data.buf, static_cast<uint32_t>(data.len));
+                    self.setStorageBufferData(index, view.buf, static_cast<uint32_t>(view.len));
                 }
                 catch (...)
                 {

--- a/src/shaders.cpp
+++ b/src/shaders.cpp
@@ -433,7 +433,7 @@ Encapsulates a GPU shader and its associated render state.
         )doc")
         .def(
             nb::init<const std::filesystem::path&, uint32_t, uint32_t, const std::vector<uint32_t>&>(), "fragment_base_path"_a,
-            "uniform_buffer_count"_a = 0, "sampler_count"_a = 1, "storage_buffer_sizes"_a = {}, R"doc(
+            "uniform_buffer_count"_a = 0, "sampler_count"_a = 1, "storage_buffer_sizes"_a = std::vector<uint32_t>{}, R"doc(
 Create a Shader instance from a fragment shader file.
 
 Args:

--- a/src/shaders.cpp
+++ b/src/shaders.cpp
@@ -433,7 +433,7 @@ Encapsulates a GPU shader and its associated render state.
         )doc")
         .def(
             nb::init<const std::filesystem::path&, uint32_t, uint32_t, const std::vector<uint32_t>&>(), "fragment_base_path"_a,
-            "uniform_buffer_count"_a = 0, "sampler_count"_a = 1, "storage_buffer_sizes"_a = std::vector<uint32_t>{}, R"doc(
+            "uniform_buffer_count"_a = 0, "sampler_count"_a = 1, "storage_buffer_sizes"_a = nb::list{}, R"doc(
 Create a Shader instance from a fragment shader file.
 
 Args:

--- a/src/shaders.cpp
+++ b/src/shaders.cpp
@@ -157,7 +157,7 @@ Shader::Shader(
         .sampler_bindings = nullptr,
         .num_storage_textures = 0,    // Not usable yet
         .storage_textures = nullptr,  // Not usable yet
-        .num_storage_buffers = m_storageBufferCount,
+        .num_storage_buffers = static_cast<int32_t>(m_storageBufferCount),
         .storage_buffers = m_storageBuffers.data(),
         .props = 0,
     };
@@ -497,7 +497,7 @@ Raises:
         )
         .def(
             "set_storage_buffer_data",
-            [](const Shader& self, const Uint32 index, nb::object data)
+            [](Shader& self, const Uint32 index, nb::object data)
             {
                 Py_buffer view;
 


### PR DESCRIPTION
The new function `void kn::shaders::Shader::setStorageBufferData(const uint32_t index, const void* data, const uint32_t len)`, with Python signature:
```python
def set_storage_buffer_data(self, index: int, data: collections.abc.Buffer, /) -> None:
    """
    Args:
        index (int): Shader buffer binding index.
        data (Buffer): Buffer-compatible object containing the bytes to be given to the shader buffer.

    Raises:
        TypeError: If the object does not provide compatible storage buffer data.
        RuntimeError: If the storage buffer data cannot be set.
    """
```
sets the data for a data storage buffer (an HLSL StructuredBuffer, untested for GLSL, but presumably an SSBO) for the fragment shader at the specified index.

It is implemented with storage buffers having their own respective GPU buffers (`SDL_GPUBuffer`) and GPU transfer buffers `SDL_GPUTransferBuffer`, with cycling turned-on for better for-frame performance.